### PR TITLE
Refactor/blueprint search and log

### DIFF
--- a/src/examples/index.js
+++ b/src/examples/index.js
@@ -5,10 +5,13 @@ const { Coverage } = require("../facade/coverage");
 const db = Knex(knexConfig);
 
 const doit = async () => {
-  const workflowId = "f81cf040-6d41-11eb-82af-1d1728424c5c";
+  const workflow = await db('workflow')
+        .where('name', 'basic')
+        .orderBy('created_at', 'desc')
+        .first();
 
   const coverage = new Coverage(db);
-  const result = await coverage.calculateCoverage(workflowId, 50);
+  const result = await coverage.calculateCoverage(workflow.id, 50);
 
   console.log(result);
   console.log("uncovered Nodes: ", result.coverage.nodes.uncovered);

--- a/src/examples/index.js
+++ b/src/examples/index.js
@@ -14,8 +14,6 @@ const doit = async () => {
   const result = await coverage.calculateCoverage(workflow.id, 50);
 
   console.log(result);
-  console.log("uncovered Nodes: ", result.coverage.nodes.uncovered);
-  console.log("uncovered Connections: ", result.coverage.connections.uncovered);
 
   process.exit(0);
 };

--- a/src/facade/coverage.js
+++ b/src/facade/coverage.js
@@ -33,24 +33,21 @@ class Coverage {
     );
 
     const result = {
-      blueprint,
-      history: {
-        processesEvaluated: processCount,
-        connections: [...new Set(execution.connections)],
-        nodes: [...new Set(execution.nodes)],
+      blueprint: {
+        name: blueprint.name,
+        id: blueprint.id
       },
+      processesEvaluated: processCount,
       coverage: {
-        nodes: {
-          value: 100 * (1 - nodesUncovered.length / blueprint.nodes.length),
-          uncovered: [...new Set(nodesUncovered)],
-        },
-        connections: {
-          value:
-            100 *
-            (1 - connectionsUncovered.length / blueprint.connections.length),
-          uncovered: [...new Set(connectionsUncovered)],
-        },
+        nodes: (100 * (1 - nodesUncovered.length / blueprint.nodes.length)).toPrecision(4) + ' %',
+        connections:
+            (100 *
+            (1 - connectionsUncovered.length / blueprint.connections.length)).toPrecision(4) + ' %',
       },
+      analysis: {
+        uncoveredNodes: [...new Set(nodesUncovered)],
+        uncoveredConnections: [...new Set(connectionsUncovered)]
+      }
     };
 
     return result;

--- a/src/facade/workflow.js
+++ b/src/facade/workflow.js
@@ -16,6 +16,7 @@ class Workflow {
 
     return {
       name: workflow.name,
+      id: workflow.workflow_id,
       nodes: [...new Set(nodes)],
       connections: [...new Set(connections)],
     };


### PR DESCRIPTION
Buscar workflow pelo nome (ao invés de ter que buscar no banco qual o id mais recente da blueprint);
Alterar o log para ter um caráter mais limpo e com informações mais relevantes.